### PR TITLE
Quiet A10, allow local script library

### DIFF
--- a/macgyver-core/src/main/java/io/macgyver/core/resource/provider/composite/CompositeResourceProvider.java
+++ b/macgyver-core/src/main/java/io/macgyver/core/resource/provider/composite/CompositeResourceProvider.java
@@ -39,25 +39,38 @@ public class CompositeResourceProvider extends ResourceProvider {
 	}
 
 	public void replaceResourceProvider(ResourceProvider rp) {
-		logger.info("removing all providers of {}",rp.getClass());
+		logger.info("removing all providers of {}", rp.getClass());
 		List<ResourceProvider> temp = Lists.newArrayList();
-		for (ResourceProvider p: resourceLoaders) {
+		for (ResourceProvider p : resourceLoaders) {
 			if (rp.getClass().isAssignableFrom(p.getClass())) {
-			
+
 				temp.add(p);
 			}
 		}
 		resourceLoaders.removeAll(temp);
-		
+
 		addResourceLoader(rp);
 	}
+
+	public void insertResourceLoader(ResourceProvider loader) {
+		addResourceLoader(loader, true);
+	}
+
 	public void addResourceLoader(ResourceProvider loader) {
+		addResourceLoader(loader, false);
+	}
+
+	private void addResourceLoader(ResourceProvider loader, boolean insert) {
 		Preconditions.checkNotNull(loader);
 		if (resourceLoaders.contains(loader)) {
 			logger.warn("resource loader already registered: {}", loader);
 			return;
 		}
-		resourceLoaders.add(loader);
+		if (insert) {
+			resourceLoaders.add(0, loader);
+		} else {
+			resourceLoaders.add(loader);
+		}
 	}
 
 	@Override
@@ -87,22 +100,21 @@ public class CompositeResourceProvider extends ResourceProvider {
 			}
 
 		}
-		throw new FileNotFoundException("resource not found: "+path);
+		throw new FileNotFoundException("resource not found: " + path);
 
 	}
 
 	@Override
 	public void refresh() throws IOException {
-		for (ResourceProvider p: resourceLoaders) {
+		for (ResourceProvider p : resourceLoaders) {
 			p.refresh();
 		}
-		
+
 	}
 
-	
 	public Optional<Resource> findResourceByHash(String hash) throws IOException {
 		Preconditions.checkNotNull(hash);
-		for (Resource r: findResources()) {
+		for (Resource r : findResources()) {
 
 			if (r.getHash().equals(hash)) {
 				return Optional.of(r);

--- a/macgyver-core/src/main/java/io/macgyver/core/resource/provider/filesystem/FileSystemResourceProvider.java
+++ b/macgyver-core/src/main/java/io/macgyver/core/resource/provider/filesystem/FileSystemResourceProvider.java
@@ -41,8 +41,7 @@ public class FileSystemResourceProvider extends ResourceProvider {
 
 	public boolean isApprovedPath(File f) {
 		try {
-			File approvedParent = Bootstrap.getInstance().getScriptsDir()
-					.getCanonicalFile();
+			File approvedParent = rootDir.getCanonicalFile();
 			while (f != null) {
 				f = f.getCanonicalFile();
 				if (f.equals(approvedParent)) {

--- a/macgyver-core/src/main/java/io/macgyver/core/script/ScriptExecutor.java
+++ b/macgyver-core/src/main/java/io/macgyver/core/script/ScriptExecutor.java
@@ -56,7 +56,7 @@ public class ScriptExecutor implements ApplicationContextAware {
 
 	public ExtensionResourceProvider getExtensionResourceLoader() {
 
-		return Kernel.getInstance().getApplicationContext()
+		return Kernel.getApplicationContext()
 				.getBean(ExtensionResourceProvider.class);
 	}
 
@@ -75,14 +75,14 @@ public class ScriptExecutor implements ApplicationContextAware {
 	public void collectBindings(Bindings b, Optional<String> lang) {
 
 		b.put("kernel", Kernel.getInstance());
-		b.put("ctx", Kernel.getInstance().getApplicationContext());
+		b.put("ctx", Kernel.getApplicationContext());
 		b.put("log", LoggerFactory.getLogger("io.macgyver.script"));
-		b.put("beans", new SpringMapAdapter(Kernel.getInstance()
+		b.put("beans", new SpringMapAdapter(Kernel
 				.getApplicationContext()));
 		b.put("services",
-				Kernel.getInstance().getApplicationContext()
+				Kernel.getApplicationContext()
 						.getBean(ServiceRegistry.class).mapAdapter());
-		BindingSupplierManager bsm = Kernel.getInstance()
+		BindingSupplierManager bsm = Kernel
 				.getApplicationContext().getBean(BindingSupplierManager.class);
 		Map<String, Object> m = bsm.collect(lang);
 		b.putAll(m);
@@ -181,9 +181,6 @@ public class ScriptExecutor implements ApplicationContextAware {
 						"could not create ScriptEngine for extension: "
 								+ getExtension(f));
 			}
-
-			ApplicationContext ctx = Kernel.getInstance()
-					.getApplicationContext();
 
 			Reader fr = new InputStreamReader(f.openInputStream());
 			closer.register(fr);


### PR DESCRIPTION
Two changes:

- Don't print out stack traces when connection to A10 fails

- Allow inserting an ResourceProvider first in ExtensionResourceProvider, to allow a local copy of a github-backed script library to take precedence (primarily for development) 
