### PR TITLE
Allow environment-specific schedules for scripts

### DIFF
--- a/macgyver-core/src/main/java/io/macgyver/core/resource/provider/composite/CompositeResourceProvider.java
+++ b/macgyver-core/src/main/java/io/macgyver/core/resource/provider/composite/CompositeResourceProvider.java
@@ -15,7 +15,10 @@ package io.macgyver.core.resource.provider.composite;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,12 +78,18 @@ public class CompositeResourceProvider extends ResourceProvider {
 
 	@Override
 	public Iterable<Resource> findResources(ResourceMatcher matcher) throws IOException {
+		
+		Set<String> paths = new HashSet<>();
+		
 		List<Resource> list = Lists.newArrayList();
 
 		for (ResourceProvider loader : resourceLoaders) {
-
-			Iterables.addAll(list, loader.findResources(matcher));
-
+			for (Iterator<Resource> iter = loader.findResources(matcher).iterator(); iter.hasNext(); ) {
+				Resource resource = iter.next();
+				if (paths.add(resource.getPath())) {
+					list.add(resource);
+				}
+			}
 		}
 
 		return list;

--- a/macgyver-core/src/main/java/io/macgyver/core/scheduler/ConcurrentExecutionNotAllowedException.java
+++ b/macgyver-core/src/main/java/io/macgyver/core/scheduler/ConcurrentExecutionNotAllowedException.java
@@ -13,15 +13,11 @@
  */
 package io.macgyver.core.scheduler;
 
-import it.sauronsoftware.cron4j.TaskExecutor;
-
 public class ConcurrentExecutionNotAllowedException extends IllegalStateException {
-
-
+	private static final long serialVersionUID = 1L;
 
 	public ConcurrentExecutionNotAllowedException(String message) {
 		super(message);
-		
 	}
 
 }

--- a/macgyver-core/src/main/java/io/macgyver/core/scheduler/CrontabExpressionExtractor.java
+++ b/macgyver-core/src/main/java/io/macgyver/core/scheduler/CrontabExpressionExtractor.java
@@ -1,0 +1,94 @@
+package io.macgyver.core.scheduler;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Optional;
+import com.google.common.io.CharStreams;
+import com.google.common.io.LineProcessor;
+
+import io.macgyver.core.Kernel;
+import io.macgyver.core.resource.Resource;
+
+public class CrontabExpressionExtractor {
+
+	private String profile = Kernel.getExecutionProfile().or("");
+
+	private Logger logger = LoggerFactory.getLogger(CrontabExpressionExtractor.class);
+
+	private class CrontabLineProcessor implements LineProcessor<List<ObjectNode>> {
+		int i = 0;
+		int last = -1;
+		List<String> lines = new ArrayList<>();
+
+		@Override
+		public boolean processLine(String line) throws IOException {
+			if (i++ > 50) {
+				// only look through the first 50 lines
+				return false;
+			}
+			if (line != null && line.contains(ScheduledTaskManager.SCHEDULE_TOKEN)) {
+				// only parse consecutive schedule lines
+				if (last < 0 || last == (i - 1)) {
+					last = i;
+				} else {
+					return false;
+				}
+				lines.add(line.substring(line.indexOf(ScheduledTaskManager.SCHEDULE_TOKEN)
+						+ ScheduledTaskManager.SCHEDULE_TOKEN.length()).trim());
+			}
+			return true;
+		}
+
+		@Override
+		public List<ObjectNode> getResult() {
+			ObjectMapper mapper = new ObjectMapper();
+			List<ObjectNode> results = new ArrayList<>();
+			lines.forEach(s -> {
+				try {
+					results.add((ObjectNode) mapper.readTree(s));
+				} catch (IOException e) {
+					logger.warn("problem parsing: {}", s);
+				}
+			});
+			return results;
+		}
+	}
+
+	public CrontabExpressionExtractor() {
+	}
+
+	public Optional<ObjectNode> extractCronExpression(Resource r) {
+		try (StringReader sr = new StringReader(r.getContentAsString())) {
+			List<ObjectNode> scheduleNodes = CharStreams.readLines(sr, new CrontabLineProcessor());
+			for (ObjectNode n : scheduleNodes) {
+				JsonNode envNode = n.path("env");
+				if (envNode.isMissingNode() || profile.startsWith(envNode.asText())) {
+					return Optional.of(n);
+				}
+			}
+			return Optional.absent();
+		} catch (IOException | RuntimeException e) {
+			try {
+				logger.warn("unable to extract cron expression: ", r.getContentAsString());
+			} catch (Exception IGNORE) {
+				logger.warn("unable to extract cron expression");
+			}
+		}
+		return Optional.absent();
+	}
+
+	public CrontabExpressionExtractor withProfile(String profile) {
+		this.profile = profile;
+		return this;
+	}
+
+}

--- a/macgyver-core/src/main/java/io/macgyver/core/scheduler/LocalScheduler.java
+++ b/macgyver-core/src/main/java/io/macgyver/core/scheduler/LocalScheduler.java
@@ -14,11 +14,9 @@
 package io.macgyver.core.scheduler;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.PostConstruct;
 
@@ -29,9 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Optional;
-import com.google.common.io.LineProcessor;
-import com.google.common.util.concurrent.Service;
 
 import io.macgyver.core.Kernel;
 import io.macgyver.core.scheduler.TaskStateManager.AgingTaskCleanup;
@@ -39,62 +34,30 @@ import io.macgyver.core.scheduler.TaskStateManager.OrphanedTaskCleanup;
 import io.macgyver.neorx.rest.NeoRxClient;
 import it.sauronsoftware.cron4j.Scheduler;
 
-public class LocalScheduler implements  Runnable, DirectScriptExecutor {
+public class LocalScheduler implements Runnable, DirectScriptExecutor {
 
 	static Logger logger = LoggerFactory.getLogger(LocalScheduler.class);
 
-	ScheduledFuture scheduledFuture;
+	ScheduledFuture<?> scheduledFuture;
 
 	@Autowired
 	Scheduler scheduler;
-	
+
 	@Autowired
 	MacGyverTaskCollector taskCollector;
 
 	@Autowired
 	NeoRxClient neo4j;
-	
+
 	@Autowired
 	TaskStateManager taskStateManager;
-	
+
 	synchronized NeoRxClient getNeoRxClient() {
-		if (neo4j==null) {
-			neo4j = Kernel.getInstance().getApplicationContext().getBean(NeoRxClient.class);
+		if (neo4j == null) {
+			Kernel.getInstance();
+			neo4j = Kernel.getApplicationContext().getBean(NeoRxClient.class);
 		}
 		return neo4j;
-	}
-	public static class CrontabLineProcessor implements LineProcessor<Optional<ObjectNode>> {
-		int i = 0;
-		String result;
-
-		@Override
-		public boolean processLine(String line) throws IOException {
-			if (i++ > 50) {
-				// only look through the first 50 lines
-				return false;
-			}
-			if (line != null && line.contains(ScheduledTaskManager.SCHEDULE_TOKEN)) {
-				result = line.substring(line.indexOf(ScheduledTaskManager.SCHEDULE_TOKEN) + ScheduledTaskManager.SCHEDULE_TOKEN.length()).trim();
-				return false;
-			}
-			return true;
-		}
-
-		@Override
-		public Optional<ObjectNode> getResult() {
-			if (result == null || result.trim().length() == 0) {
-				return Optional.absent();
-			}
-			try {
-				ObjectNode n = (ObjectNode) new ObjectMapper().readTree(result);
-
-				return Optional.fromNullable(n);
-			} catch (IOException e) {
-				logger.warn("problem parsing: {}", result);
-				return Optional.absent();
-			}
-		}
-
 	}
 
 	public boolean isMaster() {
@@ -106,19 +69,16 @@ public class LocalScheduler implements  Runnable, DirectScriptExecutor {
 		logger.info("starting scheduler...");
 
 		scheduledFuture = Executors.newScheduledThreadPool(1).scheduleWithFixedDelay(this, 0, 10, TimeUnit.SECONDS);
-	
-		Preconditions.checkNotNull(taskCollector);
-			scheduler.addTaskCollector(taskCollector);
-			scheduler.setDaemon(true);
-			scheduler.addSchedulerListener(new MacGyverScheduleListener());
-			
-			scheduler.start();
-				
-			
-			scheduler.schedule(OrphanedTaskCleanup.CRON, taskStateManager.new OrphanedTaskCleanup());
-			scheduler.schedule(AgingTaskCleanup.CRON,taskStateManager.new AgingTaskCleanup());
-	
 
+		Preconditions.checkNotNull(taskCollector);
+		scheduler.addTaskCollector(taskCollector);
+		scheduler.setDaemon(true);
+		scheduler.addSchedulerListener(new MacGyverScheduleListener());
+
+		scheduler.start();
+
+		scheduler.schedule(OrphanedTaskCleanup.CRON, taskStateManager.new OrphanedTaskCleanup());
+		scheduler.schedule(AgingTaskCleanup.CRON, taskStateManager.new AgingTaskCleanup());
 	}
 
 	@Override
@@ -130,9 +90,6 @@ public class LocalScheduler implements  Runnable, DirectScriptExecutor {
 		}
 	}
 
-
-
-
 	/**
 	 * 
 	 * 
@@ -142,11 +99,6 @@ public class LocalScheduler implements  Runnable, DirectScriptExecutor {
 		ObjectNode n = new ObjectMapper().createObjectNode();
 		n.put("script", scriptName);
 		MacGyverTask task = new MacGyverTask(n);
-
-			scheduler.launch(task);
-		
-		
+		scheduler.launch(task);
 	}
-
-
 }

--- a/macgyver-core/src/main/java/io/macgyver/core/scheduler/TaskStateManager.java
+++ b/macgyver-core/src/main/java/io/macgyver/core/scheduler/TaskStateManager.java
@@ -78,7 +78,7 @@ public class TaskStateManager implements ApplicationListener<ApplicationReadyEve
 	
 
 	public void recordUserDefinedTaskStart(String guid, String ...userData) {
-		ObjectNode n = mapper.convertValue(U.map(userData), ObjectNode.class);
+		ObjectNode n = mapper.convertValue(U.map((Object[]) userData), ObjectNode.class);
 		
 		
 	    recordUserDefinedTaskStart(guid, n);

--- a/macgyver-core/src/test/java/io/macgyver/core/scheduler/CrontabScheduleExtractorTest.java
+++ b/macgyver-core/src/test/java/io/macgyver/core/scheduler/CrontabScheduleExtractorTest.java
@@ -1,0 +1,40 @@
+package io.macgyver.core.scheduler;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.macgyver.core.resource.StringResource;
+
+public class CrontabScheduleExtractorTest {
+	private StringResource script = new StringResource(
+			"#@Schedule{\"n\": 1, \"env\": \"prod\"}\n"
+			+ "#@Schedule {\"n\": 3, \"env\": \"demo\"}\n"
+			+ "#@Schedule {\"n\": 2}\n");
+	
+	@Test
+	public void testProd() {
+		ObjectNode o = new CrontabExpressionExtractor().withProfile("prod_nevada").extractCronExpression(script).get();
+		Assertions.assertThat(o.path("n").asInt()).isEqualTo(1);
+	}
+	
+	@Test
+	public void testDev() {
+		ObjectNode o = new CrontabExpressionExtractor().withProfile("lcdev").extractCronExpression(script).get();
+		Assertions.assertThat(o.path("n").asInt()).isEqualTo(2);
+	}
+	
+	@Test
+	public void testDefault() {
+		ObjectNode o = new CrontabExpressionExtractor().extractCronExpression(script).get();
+		Assertions.assertThat(o.path("n").asInt()).isEqualTo(2);
+	}
+	
+	@Test
+	public void testDemo() {
+		ObjectNode o = new CrontabExpressionExtractor().withProfile("demo").extractCronExpression(script).get();
+		Assertions.assertThat(o.path("n").asInt()).isEqualTo(3);
+	}
+
+}

--- a/macgyver-core/src/test/java/io/macgyver/core/scheduler/ScheduledTaskManagerTest.java
+++ b/macgyver-core/src/test/java/io/macgyver/core/scheduler/ScheduledTaskManagerTest.java
@@ -13,71 +13,62 @@
  */
 package io.macgyver.core.scheduler;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringBufferInputStream;
-
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import io.macgyver.core.resource.Resource;
 import io.macgyver.core.resource.StringResource;
 
 public class ScheduledTaskManagerTest {
 
 	ObjectMapper mapper = new ObjectMapper();
-	
+
 	ScheduledTaskManager stm = new ScheduledTaskManager();
-	
+
 	@Test
 	public void testDefault() {
-			
+
 		Assertions.assertThat(stm.isSchedulerEnabled()).isTrue();
-		
+
 	}
-	
-	@Test 
+
+	@Test
 	public void testLocalDefault() {
-		ObjectNode n = mapper.createObjectNode();		
 		Assertions.assertThat(stm.isEnabled(mapper.createObjectNode())).isTrue();
 	}
 
-	@Test 
+	@Test
 	public void testEnabled() {
-		ObjectNode n = mapper.createObjectNode();
 		Assertions.assertThat(stm.isEnabled(mapper.createObjectNode().put("enabled", "true"))).isTrue();
 		Assertions.assertThat(stm.isEnabled(mapper.createObjectNode().put("enabled", "xx"))).isTrue();
-		
+
 		Assertions.assertThat(stm.isEnabled(mapper.createObjectNode().put("enabled", "false"))).isFalse();
 	}
 
-	@Test 
+	@Test
 	public void testManualScheduledScript() {
-		
-		
+
 		Assertions.assertThat(stm.isScriptManuallyScheduled(null)).isFalse();
 		Assertions.assertThat(stm.isScriptManuallyScheduled(mapper.createObjectNode())).isFalse();
-		Assertions.assertThat(stm.isScriptManuallyScheduled(mapper.createObjectNode().put("scheduledBy", "manual"))).isTrue();
+		Assertions.assertThat(stm.isScriptManuallyScheduled(mapper.createObjectNode().put("scheduledBy", "manual")))
+				.isTrue();
 	}
-		
-		
 
-	
 	@Test
 	public void testExtractCron() {
-		Assertions.assertThat(stm.extractCronExpression(new StringResource("")).isPresent()).isFalse();
-		Assertions.assertThat(stm.extractCronExpression(new StringResource("#@Schedule{}")).isPresent()).isTrue();
-		Assertions.assertThat(stm.extractCronExpression(new StringResource("// #@Schedule{}")).isPresent()).isTrue();
-		Assertions.assertThat(stm.extractCronExpression(new StringResource("// #@Schedule{\"foo\":\"bar\"}")).get().path("foo").asText()).isEqualTo("bar");
-				
-		Assertions.assertThat(stm.extractCronExpression(new StringResource("// #@Schedule{\"invalidJson:\"foo\"}")).isPresent()).isFalse();
-		
+		CrontabExpressionExtractor e = new CrontabExpressionExtractor();
+		Assertions.assertThat(e.extractCronExpression(new StringResource("")).isPresent()).isFalse();
+		Assertions.assertThat(e.extractCronExpression(new StringResource("#@Schedule{}")).isPresent()).isTrue();
+		Assertions.assertThat(e.extractCronExpression(new StringResource("// #@Schedule{}")).isPresent()).isTrue();
+		Assertions.assertThat(e.extractCronExpression(new StringResource("// #@Schedule{\"foo\":\"bar\"}")).get()
+				.path("foo").asText()).isEqualTo("bar");
+		Assertions
+				.assertThat(
+						e.extractCronExpression(new StringResource("// #@Schedule{\"invalidJson:\"foo\"}")).isPresent())
+				.isFalse();
 	}
-		
-	
 
+	
 }


### PR DESCRIPTION
Allows scripts to contain multiple cron schedule lines, for example:

    // #@Schedule {"cron":"3 */4 * * *"}
    // #@Schedule !prod {"enabled":"false"}

Each schedule line has an optional pattern which matches if `Kernel.getExecutionProfile()` starts with the pattern (or does not start with if the pattern begins with `!`).

The first schedule that matches takes effect.