### PR TITLE
Allow for AWS credentials from STS AssumeRole

### DIFF
--- a/macgyver-plugin-cloud-aws/src/main/java/io/macgyver/plugin/cloud/aws/AWSServiceClientAssumeRoleCredentialsProvider.java
+++ b/macgyver-plugin-cloud-aws/src/main/java/io/macgyver/plugin/cloud/aws/AWSServiceClientAssumeRoleCredentialsProvider.java
@@ -1,0 +1,58 @@
+package io.macgyver.plugin.cloud.aws;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+
+import io.macgyver.core.service.ServiceRegistry;
+
+public class AWSServiceClientAssumeRoleCredentialsProvider implements AWSCredentialsProvider {
+
+	private final ServiceRegistry registry;
+	private final String sourceServiceName;
+	private final String roleArn;
+	// this is going to be a mouthful...
+	private volatile STSAssumeRoleSessionCredentialsProvider stsAssumeRoleSessionCredentialsProvider;
+
+	public AWSServiceClientAssumeRoleCredentialsProvider(ServiceRegistry registry, String sourceServiceName,
+			String roleArn) {
+		this.registry = registry;
+		this.sourceServiceName = sourceServiceName;
+		this.roleArn = roleArn;
+	}
+
+	@Override
+	public AWSCredentials getCredentials() {
+		if (stsAssumeRoleSessionCredentialsProvider == null) {
+			synchronized (this) {
+				if (stsAssumeRoleSessionCredentialsProvider == null) {
+					/*
+					 * We defer the lookup of the source service until we
+					 * actually need it
+					 */
+					AWSServiceClient sourceService = registry.get(sourceServiceName, AWSServiceClient.class);
+					String roleSessionName = System.getProperty("user.name");
+					try {
+						String host = InetAddress.getLocalHost().getHostName();
+						roleSessionName = roleSessionName + "@" + host;
+					} catch (UnknownHostException e) {
+					}
+					stsAssumeRoleSessionCredentialsProvider = new STSAssumeRoleSessionCredentialsProvider(
+							sourceService.getCredentialsProvider(), roleArn, roleSessionName);
+				}
+			}
+		}
+		return stsAssumeRoleSessionCredentialsProvider.getCredentials();
+	}
+
+	@Override
+	public void refresh() {
+		if (stsAssumeRoleSessionCredentialsProvider != null) {
+			stsAssumeRoleSessionCredentialsProvider.refresh();
+		}
+	}
+
+}


### PR DESCRIPTION
@if6was9 @ashleycsun this enables getting AWS credentials via STS/AssumeRole

To enable, change `services.groovy` as:

    awsNonprod {
        serviceType="aws"
        sourceService="aws"
        assumeRoleName="macgyver-svc-role"
        accountId="XXX"
        regions="us-west-2,us-east-1"
    }

NB - fallback to the default credentials provider will only occur if neither static credentials nor assume role info is given, or if `enableDefaultCredentials = true` is set.

This patch is required to move macgyver itself into AWS (assume multiple-account access is needed.)