### PR TITLE
Standardizing the name update timestamp name

### DIFF
--- a/macgyver-plugin-cloud-aws/src/main/java/io/macgyver/plugin/cloud/aws/scanner/LaunchConfigScanner.java
+++ b/macgyver-plugin-cloud-aws/src/main/java/io/macgyver/plugin/cloud/aws/scanner/LaunchConfigScanner.java
@@ -51,7 +51,7 @@ public class LaunchConfigScanner extends AWSServiceScanner {
 			ObjectNode n = convertAwsObject(config, region);
 			List<String> securityGroups = getSecurityGroups(config);
 
-			String cypher = "merge (x:AwsLaunchConfig {aws_arn:{aws_arn}}) set x+={props}, x.aws_securityGroups={sg}, x.updateTimestamp=timestamp() return x";
+			String cypher = "merge (x:AwsLaunchConfig {aws_arn:{aws_arn}}) set x+={props}, x.aws_securityGroups={sg}, x.updateTs=timestamp() return x";
 		
 			Preconditions.checkNotNull(getNeoRxClient());
 


### PR DESCRIPTION
Standardizing the name so that GraphNodeGarbageCollector can clean up based on the updateTs.