### PR TITLE
Autofocus user name field on login page

### DIFF
--- a/macgyver-core/src/main/resources/web/templates/macgyver-login.gsp
+++ b/macgyver-core/src/main/resources/web/templates/macgyver-login.gsp
@@ -33,7 +33,7 @@
         <p class="login-box-msg">MacGyver Login</p>
         <form action="/login" method="post">
           <div class="form-group has-feedback">
-            <input type="username" class="form-control" placeholder="Username" name="username">
+            <input type="username" class="form-control" placeholder="Username" name="username" autofocus="autofocus">
             <span class="glyphicon  form-control-feedback"></span>
           </div>
           <div class="form-group has-feedback">


### PR DESCRIPTION
@if6was9 please review. I wasn't able to get macgyver up and running locally to test this, but this should autofocus the user name field, which will save me several seconds of my life :).

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus

BTW, This is the error I'm getting when trying to run it locally (I have neo4j installed and running):

> ./gradlew run
...
* What went wrong:
Execution failed for task ':macgyver-cli:run'.
> Process 'command '/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java'' finished with non-zero exit value 1